### PR TITLE
Revert validation to array introduced in 3.1.41 (#3742)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,3 @@
-
 # Changelog
 
 All notable changes to this project will be documented in this file.
@@ -6,7 +5,6 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Changed
-- Support `WithValidation` concern to allow validations with `Excel::toArray()` and `Excel::toCollection()`
 - Cast empty headings to indexed integer
 - Adds `isEmptyWhen` to customize is row empty logic.
 

--- a/src/Sheet.php
+++ b/src/Sheet.php
@@ -360,12 +360,8 @@ class Sheet
                 $row = $import->map($row);
             }
 
-            if ($import instanceof WithValidation) {
-                if (method_exists($import, 'prepareForValidation')) {
-                    $row = $import->prepareForValidation($row, $index);
-                }
-
-                $rows = $this->validated($import, $startRow, $rows);
+            if ($import instanceof WithValidation && method_exists($import, 'prepareForValidation')) {
+                $row = $import->prepareForValidation($row, $index);
             }
 
             $rows[] = $row;

--- a/tests/Concerns/WithValidationTest.php
+++ b/tests/Concerns/WithValidationTest.php
@@ -88,66 +88,6 @@ class WithValidationTest extends TestCase
     /**
      * @test
      */
-    public function can_validate_simple_to_array()
-    {
-        $import = new class implements WithValidation
-        {
-            use Importable;
-
-            public function rules(): array
-            {
-                return ['phone' => 'required'];
-            }
-        };
-
-        try {
-            $import->toArray('import-users-with-headings.xlsx');
-        } catch (ValidationException $e) {
-            $this->validateFailure($e, 1, 'phone', [
-                'The phone field is required.',
-            ]);
-
-            $this->assertEquals([
-                [
-                    'There was an error on row 1. The phone field is required.',
-                ],
-            ], $e->errors());
-        }
-    }
-
-    /**
-     * @test
-     */
-    public function can_validate_simple_to_collection()
-    {
-        $import = new class implements WithValidation
-        {
-            use Importable;
-
-            public function rules(): array
-            {
-                return ['phone' => 'required'];
-            }
-        };
-
-        try {
-            $import->toCollection('import-users-with-headings.xlsx');
-        } catch (ValidationException $e) {
-            $this->validateFailure($e, 1, 'phone', [
-                'The phone field is required.',
-            ]);
-
-            $this->assertEquals([
-                [
-                    'There was an error on row 1. The phone field is required.',
-                ],
-            ], $e->errors());
-        }
-    }
-
-    /**
-     * @test
-     */
     public function can_validate_rows_with_closure_validation_rules()
     {
         $import = new class implements ToModel, WithValidation


### PR DESCRIPTION
* Revert "Simplify validations by using only one concern (#3642)"

This reverts commit d4fb556ebcc7edafa870d4ae2e98436c04ea2689.

# Conflicts:
#	CHANGELOG.md

* Revert "Allow validations with toArray (#3641)"

This reverts commit 37b4143c5f377a15438b71761572cbf281abd7d1.

# Conflicts:
#	CHANGELOG.md

Co-authored-by: Michael van der Griendt <griendt@kyos.com>

Please take note of our contributing guidelines: https://docs.laravel-excel.com/3.1/getting-started/contributing.html
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

1️⃣  Why should it be added? What are the benefits of this change?

2️⃣  Does it contain multiple, unrelated changes? Please separate the PRs out.

3️⃣  Does it include tests, if possible?

4️⃣  Any drawbacks? Possible breaking changes?

5️⃣  Mark the following tasks as done:

- [ ] Checked the codebase to ensure that your feature doesn't already exist.
- [ ] Take note of the contributing guidelines.
- [ ] Checked the pull requests to ensure that another person hasn't already submitted a fix.
- [ ] Added tests to ensure against regression.
- [ ] Updated the changelog

6️⃣  Thanks for contributing! 🙌
